### PR TITLE
Allow utf-8 characters in name in createUser method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.0.3
+
+**Bug fixes**
+
+* gh-16 The buttons should not appear in the back-end of the site by default 
+
 # 1.0.2
 
 **Bug fixes**

--- a/build/templates/plg_system_sociallogin.xml
+++ b/build/templates/plg_system_sociallogin.xml
@@ -40,7 +40,7 @@
 						type="text"
 						label="PLG_SYSTEM_SOCIALLOGIN_CONFIG_BACKENDLOGINMODULES_LABEL"
 						description="PLG_SYSTEM_SOCIALLOGIN_CONFIG_BACKENDLOGINMODULES_DESC"
-						default=""
+						default="none"
 				/>
 
 				<field

--- a/plugins/system/sociallogin/language/en-GB/en-GB.plg_system_sociallogin.sys.ini
+++ b/plugins/system/sociallogin/language/en-GB/en-GB.plg_system_sociallogin.sys.ini
@@ -5,8 +5,11 @@
 PLG_SYSTEM_SOCIALLOGIN="System - Akeeba Social Login"
 PLG_SYSTEM_SOCIALLOGIN_DESCRIPTION="Displays the social network login buttons. Use the options to tell this plugin where it should auto-append the social login buttons or use template overrides according to the documentation."
 
-PLG_SYSTEM_SOCIALLOGIN_CONFIG_LOGINMODULES_LABEL="Login Modules' Names"
-PLG_SYSTEM_SOCIALLOGIN_CONFIG_LOGINMODULES_DESC="Enter the comma separated list of namen of modules to append the social buttons automatically, e.g. <code>mod_login, mod_ajaxlogin</code>. Set this to <code>none</code> to prevent this behavior. In this case you must make template overrides according to the documentation."
+PLG_SYSTEM_SOCIALLOGIN_CONFIG_LOGINMODULES_LABEL="Frontend Login Modules' Names"
+PLG_SYSTEM_SOCIALLOGIN_CONFIG_LOGINMODULES_DESC="Enter the comma separated list of names of frontend modules. The social buttons will be appended to them automatically, e.g. <code>mod_login, mod_ajaxlogin</code>. Set this to <code>none</code> to prevent this behavior. In this case you must make template overrides according to the documentation."
+
+PLG_SYSTEM_SOCIALLOGIN_CONFIG_BACKENDLOGINMODULES_LABEL="Backend Login Modules' Names"
+PLG_SYSTEM_SOCIALLOGIN_CONFIG_BACKENDLOGINMODULES_DESC="Enter the comma separated list of names of backend modules. The social buttons will be appended to them automatically, e.g. <code>mod_login, mod_ajaxlogin</code>. Set this to <code>none</code> to prevent this behavior. In this case you must make template overrides according to the documentation."
 
 PLG_SYSTEM_SOCIALLOGIN_CONFIG_INTERCEPTLOGIN_LABEL="Add buttons to login page"
 PLG_SYSTEM_SOCIALLOGIN_CONFIG_INTERCEPTLOGIN_DESC="When enabled the plugin will automatically append the social login buttons to the end of the login page created by Joomla's com_users. Otherwise you must make template overrides according to the documentation."

--- a/plugins/system/sociallogin/sociallogin.php
+++ b/plugins/system/sociallogin/sociallogin.php
@@ -75,12 +75,14 @@ class plgSystemSociallogin extends JPlugin
 		$this->loadLanguage();
 
 		// Get the configured list of login modules and convert it to an actual array
-		$loginModulesParameter = SocialLoginHelperJoomla::isAdminPage() ? 'backendloginmodules' : 'loginmodules';
+		$isAdminPage           = SocialLoginHelperJoomla::isAdminPage();
+		$loginModulesParameter = $isAdminPage ? 'backendloginmodules' : 'loginmodules';
+		$defaultModules        = $isAdminPage ? 'none' : 'mod_login';
 		$loginModules = $this->params->get($loginModulesParameter);
-		$loginModules = trim($loginModules);
-		$loginModules = empty($loginModules) ? 'mod_login' : $loginModules;
-		$loginModules = explode(',', $loginModules);
-		$this->loginModules = array_map('trim', $loginModules);
+		$loginModules          = trim($loginModules);
+		$loginModules          = empty($loginModules) ? $defaultModules : $loginModules;
+		$loginModules          = explode(',', $loginModules);
+		$this->loginModules    = array_map('trim', $loginModules);
 
 		// Load the other plugin parameters
 		$this->interceptLogin = $this->params->get('interceptlogin', 1);


### PR DESCRIPTION
### \plugins\system\sociallogin\helper\login.php:296

`		// Try to create a username from the full name`
`		$username = preg_replace('/[^\w]/us', '.', $name);`
`		$username = strtolower($username);`

function strtolower not work with utf-8 characters, eg: my name:
`strtolower(preg_replace('/[^\w]/us', '.', 'Krzysztof Kozłowski'))` return `krzysztof.koz�owski` Joomla throws error.

### System information (as much as possible)
* **Joomla! version**: 3.8.0
